### PR TITLE
Fixed axeDecorator for playwright/test 1.60+

### DIFF
--- a/axeDecorator.ts
+++ b/axeDecorator.ts
@@ -36,7 +36,7 @@ export function axeScan<This, Args extends any[], Return>() {
             const accessibilityConfig = loadEnvConfig()
 
             if (accessibilityConfig.scan) {
-                const page: Page | undefined = Object.values(this).find((prop): prop is Page => prop?.constructor?.name === 'Page');
+                const page: Page | undefined = Object.values(this).find((prop): prop is Page => prop?.constructor?.name === '_Page');
 
                 if (!page) {
                     console.warn(`Page not found in context in args [${Object.values(this)}].\n(Make sure you are using the decorator on a method that has access to the Playwright Page);\nSkipping axe scan.\n`);
@@ -44,7 +44,6 @@ export function axeScan<This, Args extends any[], Return>() {
                 }
 
                 let axeBuilder = new AxeBuilder({page});
-                console.log(accessibilityConfig.withRules)
                 if (accessibilityConfig.tags.length > 0) axeBuilder.withTags(accessibilityConfig.tags);
                 if (accessibilityConfig.withRules.length > 0) axeBuilder.withRules(accessibilityConfig.withRules);
                 if (accessibilityConfig.excludeRules.length > 0) axeBuilder.disableRules(accessibilityConfig.excludeRules);

--- a/package.json
+++ b/package.json
@@ -42,12 +42,12 @@
     "url": "git+https://github.com/eotsevych/axe-playwright-report.git"
   },
   "peerDependencies": {
-    "@playwright/test": ">=1.44.0",
-    "@axe-core/playwright": ">=4.10.0"
+    "@playwright/test": ">=1.60.0",
+    "@axe-core/playwright": ">=4.11.0"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.0",
-    "@playwright/test": "^1.56.1",
+    "@playwright/test": "^1.61.0",
     "@types/node": "^20.8.0",
     "dotenv": "^16.3.1",
     "typescript": "^5.2.2"


### PR DESCRIPTION
The decorator stopped working after upgrading `playwright/test` from `1.58` to `1.60`.

I'm getting this `console.warn`:
```
Page not found in context in args [[object Object]].
(Make sure you are using the decorator on a method that has access to the Playwright Page);
Skipping axe scan.
```


Quick test 
```ts
// write it to test.ts and run with node test.ts
import { webkit } from "playwright"; 

(async () => {
  const browser = await webkit.launch();
  const context = await browser.newContext();
  const page = await context.newPage();
  console.log({ name: page.constructor.name });
  // outputs 'Page' with 1.58, and '_Page' with 1.60
  await browser.close();
})();

```

[The decorator checks on the existence of ](https://github.com/eotsevych/axe-playwright-report/blob/103d8c31244d57a4e82c89671fd89d40d006fbe9/axeDecorator.ts#L39)`page.constructor.name === 'Page'` but with v1.60.0 the string is now `_Page`


------

I think the decorator could be improved:

1.  By changing line `39` for `const page: Page | undefined = this.page`. Documentation already states you need to specify a property named `page`. Doesn't it? 
2. Throw an `Error` instead of just console.warn

btw, It's a great tool!

